### PR TITLE
Fix Decimal in SYS_TICK_FREQ and add parentheses around number

### DIFF
--- a/system/time/templates/system/system_config.h.ftl
+++ b/system/time/templates/system/system_config.h.ftl
@@ -1,11 +1,11 @@
 /* TIME System Service Configuration Options */
-#define SYS_TIME_INDEX_0                     0
-#define SYS_TIME_MAX_TIMERS                  ${SYS_TIME_MAX_TIMERS?string}
-#define SYS_TIME_HW_COUNTER_WIDTH            ${.vars["${SYS_TIME_PLIB?lower_case}"].TIMER_WIDTH}
+#define SYS_TIME_INDEX_0                     (0)
+#define SYS_TIME_MAX_TIMERS                  (${SYS_TIME_MAX_TIMERS?string})
+#define SYS_TIME_HW_COUNTER_WIDTH            (${.vars["${SYS_TIME_PLIB?lower_case}"].TIMER_WIDTH})
 <#if SYS_TIME_OPERATING_MODE == "TICKLESS">
-#define SYS_TIME_HW_COUNTER_PERIOD           ${.vars["${SYS_TIME_PLIB?lower_case}"].TIMER_PERIOD_MAX}U
+#define SYS_TIME_HW_COUNTER_PERIOD           (${.vars["${SYS_TIME_PLIB?lower_case}"].TIMER_PERIOD_MAX}U)
 #define SYS_TIME_HW_COUNTER_HALF_PERIOD	     (SYS_TIME_HW_COUNTER_PERIOD>>1)
-#define SYS_TIME_CPU_CLOCK_FREQUENCY         ${core.CPU_CLOCK_FREQUENCY}
+#define SYS_TIME_CPU_CLOCK_FREQUENCY         (${core.CPU_CLOCK_FREQUENCY})
 <#if core.CoreArchitecture == "CORTEX-M7">
     <#lt>#define SYS_TIME_COMPARE_UPDATE_EXECUTION_CYCLES      (900)
 </#if>
@@ -32,5 +32,5 @@
 </#if>
 <#else>
 <#assign SYS_TICK_FREQ = (SYS_TIME_ACHIEVABLE_TICK_RATE_HZ/100000)>
-#define SYS_TIME_TICK_FREQ_IN_HZ             ${SYS_TICK_FREQ}
+#define SYS_TIME_TICK_FREQ_IN_HZ             (${SYS_TICK_FREQ?string["0"]})
 </#if>


### PR DESCRIPTION
MHC generate code decimal number for SYS_TICK_FREQ.
With french locale, Freemaker produce all decimal numbers with comma that generate compile errors.

For example :
`#define SYS_TIME_TICK_FREQ_IN_HZ             1000,08`

Result
```
../src/config/default/system/time/src/sys_time.c: In function 'SYS_TIME_CounterInit':
../src/config/default/system/time/src/sys_time.c:480:40: error: invalid digit "8" in octal constant
     counterObj->hwTimerTickFreq = SYS_TIME_TICK_FREQ_IN_HZ;
                                        ^
../src/config/default/system/time/src/sys_time.c:483:85: error: invalid digit "8" in octal constant
     counterObj->hwTimerPeriodValue = counterObj->timePlib->timerFrequencyGet()/SYS_TIME_TICK_FREQ_IN_HZ;
                                                                                     ^
make[2]: *** [build/default/production/_ext/101884895/sys_time.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```