### PR TITLE
SST26 Driver Demo Application: Erase Sector Bug Fix

### DIFF
--- a/apps/driver/sqi_flash/sst26/sst26_flash_read_write/firmware/src/app.c
+++ b/apps/driver/sqi_flash/sst26/sst26_flash_read_write/firmware/src/app.c
@@ -179,7 +179,7 @@ void APP_Tasks ( void )
 
         case APP_STATE_ERASE_FLASH:
         {
-            if (DRV_SST26_SectorErase(appData.handle, (MEM_ADDRESS + erase_index) != true))
+            if (DRV_SST26_SectorErase(appData.handle, (MEM_ADDRESS + erase_index)) != true)
             {
                 appData.state = APP_STATE_ERROR;
             }


### PR DESCRIPTION
Fix bug that causes all sector erase commands to only erase the first sector on the SST26.

A misplaced close-parenthesis causes the sector erase command in the demo app for the SST26 driver to always erase the first sector.