### PR TITLE
Fix propagation of error code in LITTLEFS_write()

### DIFF
--- a/system/fs/src/sys_fs_littlefs_interface.c.ftl
+++ b/system/fs/src/sys_fs_littlefs_interface.c.ftl
@@ -573,7 +573,7 @@ int LITTLEFS_write (
     uintptr_t handle,   /* Pointer to the file object */
     const void *buff,   /* Pointer to the data to be written */
     uint32_t btw,       /* Number of bytes to write */
-    uint32_t* bw        /* Pointer to number of bytes written */
+    int32_t* bw        /* Pointer to number of bytes written */
 )
 {
     lfs_t *fs = NULL;

--- a/system/fs/templates/sys_fs_littlefs_interface.h.ftl
+++ b/system/fs/templates/sys_fs_littlefs_interface.h.ftl
@@ -83,7 +83,7 @@ bool LITTLEFS_eof(uintptr_t handle);
 uint32_t LITTLEFS_size(uintptr_t handle);
 
 <#if SYS_FS_LFS_READONLY == false>
-int LITTLEFS_write (uintptr_t handle, const void* buff, uint32_t btw, uint32_t* bw);
+int LITTLEFS_write (uintptr_t handle, const void* buff, uint32_t btw, int32_t* bw);
 
 int LITTLEFS_mkdir (const char* path);
 


### PR DESCRIPTION
The bytes-written argument must be signed, otherwise the check `if (*bw < 0)` will always yield false and the error code isn't available with SYS_FS_FileError(..).