### PR TITLE
SYS Time: Allow setting of 64 bit value

### DIFF
--- a/system/time/src/tickbased/sys_time.c.ftl
+++ b/system/time/src/tickbased/sys_time.c.ftl
@@ -577,22 +577,18 @@ uint32_t SYS_TIME_CounterGet ( void )
 
 void SYS_TIME_CounterSet ( uint32_t count )
 {
-    bool interruptState;
-
-	interruptState = SYS_INT_Disable();
-
-    gSystemCounterObj.swCounter64 = count;
-
-    SYS_INT_Restore(interruptState);
+    SYS_TIME_Counter64Set((uint64_t) count);
 }
 
 void SYS_TIME_Counter64Set ( uint64_t count )
 {
+    SYS_TIME_COUNTER_OBJ * counterObj = (SYS_TIME_COUNTER_OBJ *)&gSystemCounterObj;
     bool interruptState;
 
     interruptState = SYS_INT_Disable();
 
-    gSystemCounterObj.swCounter64 = count;
+    counterObj->swCounter64 = count;
+    counterObj->hwTimerPreviousValue = counterObj->timePlib->timerCounterGet();
 
     SYS_INT_Restore(interruptState);
 }

--- a/system/time/src/tickbased/sys_time.c.ftl
+++ b/system/time/src/tickbased/sys_time.c.ftl
@@ -586,6 +586,17 @@ void SYS_TIME_CounterSet ( uint32_t count )
     SYS_INT_Restore(interruptState);
 }
 
+void SYS_TIME_CounterSet64 ( uint64_t count )
+{
+    bool interruptState;
+
+    interruptState = SYS_INT_Disable();
+
+    gSystemCounterObj.swCounter64 = count;
+
+    SYS_INT_Restore(interruptState);
+}
+
 /* MISRA C-2012 Rule 10.8 deviated:2 Deviation record ID -  H3_MISRAC_2012_R_10_8_DR_1 */
 <#if core.COVERITY_SUPPRESS_DEVIATION?? && core.COVERITY_SUPPRESS_DEVIATION>
 #pragma coverity compliance block deviate:2 "MISRA C-2012 Rule 10.8" "H3_MISRAC_2012_R_10_8_DR_1"

--- a/system/time/src/tickbased/sys_time.c.ftl
+++ b/system/time/src/tickbased/sys_time.c.ftl
@@ -586,7 +586,7 @@ void SYS_TIME_CounterSet ( uint32_t count )
     SYS_INT_Restore(interruptState);
 }
 
-void SYS_TIME_CounterSet64 ( uint64_t count )
+void SYS_TIME_Counter64Set ( uint64_t count )
 {
     bool interruptState;
 

--- a/system/time/src/tickless/sys_time.c.ftl
+++ b/system/time/src/tickless/sys_time.c.ftl
@@ -757,7 +757,7 @@ void SYS_TIME_CounterSet ( uint32_t count )
     SYS_INT_Restore(interruptState);
 }
 
-void SYS_TIME_CounterSet64 ( uint64_t count )
+void SYS_TIME_Counter64Set ( uint64_t count )
 {
     bool interruptState;
 

--- a/system/time/src/tickless/sys_time.c.ftl
+++ b/system/time/src/tickless/sys_time.c.ftl
@@ -757,6 +757,17 @@ void SYS_TIME_CounterSet ( uint32_t count )
     SYS_INT_Restore(interruptState);
 }
 
+void SYS_TIME_CounterSet64 ( uint64_t count )
+{
+    bool interruptState;
+
+    interruptState = SYS_INT_Disable();
+
+    gSystemCounterObj.swCounter64 = count;
+
+    SYS_INT_Restore(interruptState);
+}
+
 uint32_t  SYS_TIME_CountToUS ( uint32_t count )
 {
     return (uint32_t) (((uint64_t)count * 1000000U) / gSystemCounterObj.hwTimerFrequency);

--- a/system/time/src/tickless/sys_time.c.ftl
+++ b/system/time/src/tickless/sys_time.c.ftl
@@ -748,22 +748,18 @@ uint32_t SYS_TIME_CounterGet ( void )
 
 void SYS_TIME_CounterSet ( uint32_t count )
 {
-    bool interruptState;
-
-    interruptState = SYS_INT_Disable();
-
-    gSystemCounterObj.swCounter64 = count;
-
-    SYS_INT_Restore(interruptState);
+    SYS_TIME_Counter64Set((uint64_t) count);
 }
 
 void SYS_TIME_Counter64Set ( uint64_t count )
 {
+    SYS_TIME_COUNTER_OBJ * counterObj = (SYS_TIME_COUNTER_OBJ *)&gSystemCounterObj;
     bool interruptState;
 
     interruptState = SYS_INT_Disable();
 
-    gSystemCounterObj.swCounter64 = count;
+    counterObj->swCounter64 = count;
+    counterObj->hwTimerPreviousValue = counterObj->timePlib->timerCounterGet();
 
     SYS_INT_Restore(interruptState);
 }

--- a/system/time/sys_time.h
+++ b/system/time/sys_time.h
@@ -853,6 +853,35 @@ uint64_t SYS_TIME_Counter64Get ( void );
 
 void SYS_TIME_CounterSet ( uint32_t count );
 
+// *****************************************************************************
+/* Function:
+    void SYS_TIME_CounterSet64 ( uint64_t count )
+
+  Summary:
+    Sets the common 64-bit system counter value.
+
+  Description:
+    Sets the current "live" value of the common 64-bit system counter.
+
+  Precondition:
+    The SYS_TIME_Initialize function should have been called before calling this
+    function.
+
+  Parameters:
+    count  - The 64-bit counter value to write to the common system counter.
+
+  Returns:
+    None
+
+  Example:
+    SYS_TIME_CounterSet(1000);
+
+  Remarks:
+    None.
+*/
+
+void SYS_TIME_CounterSet64 ( uint64_t count );
+
 
 // *****************************************************************************
 /* Function:

--- a/system/time/sys_time.h
+++ b/system/time/sys_time.h
@@ -855,7 +855,7 @@ void SYS_TIME_CounterSet ( uint32_t count );
 
 // *****************************************************************************
 /* Function:
-    void SYS_TIME_CounterSet64 ( uint64_t count )
+    void SYS_TIME_Counter64Set ( uint64_t count )
 
   Summary:
     Sets the common 64-bit system counter value.
@@ -880,7 +880,7 @@ void SYS_TIME_CounterSet ( uint32_t count );
     None.
 */
 
-void SYS_TIME_CounterSet64 ( uint64_t count );
+void SYS_TIME_Counter64Set ( uint64_t count );
 
 
 // *****************************************************************************


### PR DESCRIPTION
Currently there is only a setter for 32 Bit values, which prevents us from setting larger time values.